### PR TITLE
Add external key refresh scheduler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ VERTEX_EXPRESS_BASE_URL=https://aiplatform.googleapis.com/v1beta1/publishers/goo
 EXTERNAL_KEY_URL=
 EXTERNAL_KEY_SERVICE_TOKEN=
 EXTERNAL_KEY_JWT_SECRET=
+EXTERNAL_KEY_REFRESH_INTERVAL_HOURS=1
 TEST_MODEL=gemini-1.5-flash
 THINKING_MODELS=["gemini-2.5-flash-preview-04-17"]
 THINKING_BUDGET_MAP={"gemini-2.5-flash-preview-04-17": 4000}

--- a/app/config/config.py
+++ b/app/config/config.py
@@ -100,6 +100,7 @@ class Settings(BaseSettings):
 
     # 调度器配置
     CHECK_INTERVAL_HOURS: int = 1  # 默认检查间隔为1小时
+    EXTERNAL_KEY_REFRESH_INTERVAL_HOURS: int = 1  # 外部 Key 刷新间隔
     TIMEZONE: str = "Asia/Shanghai"  # 默认时区
 
     # github

--- a/app/scheduler/scheduled_tasks.py
+++ b/app/scheduler/scheduled_tasks.py
@@ -8,6 +8,7 @@ from app.service.chat.gemini_chat_service import GeminiChatService
 from app.service.error_log.error_log_service import delete_old_error_logs
 from app.service.key.key_manager import get_key_manager_instance
 from app.service.request_log.request_log_service import delete_old_request_logs_task
+from app.service.config.config_service import ConfigService
 
 logger = Logger.setup_logger("scheduler")
 
@@ -109,6 +110,17 @@ def setup_scheduler():
     )
     logger.info(
         f"Key check job scheduled to run every {settings.CHECK_INTERVAL_HOURS} hour(s)."
+    )
+
+    scheduler.add_job(
+        ConfigService.refresh_external_key,
+        "interval",
+        hours=settings.EXTERNAL_KEY_REFRESH_INTERVAL_HOURS,
+        id="refresh_external_key_job",
+        name="Refresh External API Key",
+    )
+    logger.info(
+        f"External key refresh job scheduled to run every {settings.EXTERNAL_KEY_REFRESH_INTERVAL_HOURS} hour(s)."
     )
 
     # 新增：添加自动删除错误日志的定时任务，每天凌晨3点执行

--- a/app/static/js/config_editor.js
+++ b/app/static/js/config_editor.js
@@ -690,6 +690,9 @@ async function initConfig() {
     if (typeof config.EXTERNAL_KEY_JWT_SECRET === "undefined") {
       config.EXTERNAL_KEY_JWT_SECRET = "";
     }
+    if (typeof config.EXTERNAL_KEY_REFRESH_INTERVAL_HOURS === "undefined") {
+      config.EXTERNAL_KEY_REFRESH_INTERVAL_HOURS = 1;
+    }
     // --- 新增：处理 PROXIES 默认值 ---
     if (!config.PROXIES || !Array.isArray(config.PROXIES)) {
       config.PROXIES = []; // 默认为空数组
@@ -771,6 +774,7 @@ async function initConfig() {
       EXTERNAL_KEY_URL: "",
       EXTERNAL_KEY_SERVICE_TOKEN: "",
       EXTERNAL_KEY_JWT_SECRET: "",
+      EXTERNAL_KEY_REFRESH_INTERVAL_HOURS: 1,
       THINKING_MODELS: [],
       THINKING_BUDGET_MAP: {},
       AUTO_DELETE_ERROR_LOGS_ENABLED: false,

--- a/app/templates/config_editor.html
+++ b/app/templates/config_editor.html
@@ -1743,6 +1743,25 @@ endblock %} {% block head_extra_styles %}
           >
         </div>
 
+        <!-- 外部 Key 刷新间隔 -->
+        <div class="mb-6">
+          <label
+            for="EXTERNAL_KEY_REFRESH_INTERVAL_HOURS"
+            class="block font-semibold mb-2 text-gray-700"
+            >外部 Key 刷新间隔（小时）</label
+          >
+          <input
+            type="number"
+            id="EXTERNAL_KEY_REFRESH_INTERVAL_HOURS"
+            name="EXTERNAL_KEY_REFRESH_INTERVAL_HOURS"
+            min="1"
+            class="w-full px-4 py-3 rounded-lg form-input-themed"
+          />
+          <small class="text-gray-500 mt-1 block"
+            >定时刷新外部 API Key 的间隔时间（单位：小时）</small
+          >
+        </div>
+
         <!-- 时区 -->
         <div class="mb-6">
           <label for="TIMEZONE" class="block font-semibold mb-2 text-gray-700"


### PR DESCRIPTION
## Summary
- add `EXTERNAL_KEY_REFRESH_INTERVAL_HOURS` setting
- expose setting in env example and config editor UI
- refresh external key periodically via scheduler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68523a21ffb48329bc5366b41899751b