### PR TITLE
Improve /keys error handling

### DIFF
--- a/app/templates/keys_status.html
+++ b/app/templates/keys_status.html
@@ -1954,8 +1954,11 @@ endblock %} {% block head_extra_styles %}
 
 {% endblock %} {% block body_scripts %}
 <script>
-  // keys_status.html specific JavaScript initialization is now handled by keys_status.js
-  // The DOMContentLoaded listener in keys_status.js will execute after the DOM is ready.
-  // No inline script needed here anymore.
+  // keys_status.html specific JavaScript initialization is handled by keys_status.js
+  {% if error_message %}
+  document.addEventListener("DOMContentLoaded", function () {
+    showNotification("{{ error_message }}", "error");
+  });
+  {% endif %}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- handle specific errors in `/keys` route and return message to template
- display error toast on keys page when `error_message` is provided

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68523e71c094832994f2ae3bb5ee9bb8