### PR TITLE
更新 refresh_external_key 邏輯

### DIFF
--- a/app/service/config/config_service.py
+++ b/app/service/config/config_service.py
@@ -199,7 +199,16 @@ class ConfigService:
     async def refresh_external_key() -> str:
         """從外部服務取得 Gemini API Key 並刷新設定"""
         key = await fetch_external_key()
-        await ConfigService.update_config({"API_KEYS": [key]})
+
+        # 讀取當前設定的 API Keys，若不存在則初始化為空列表
+        current_keys: List[str] = list(settings.API_KEYS) if isinstance(settings.API_KEYS, list) else []
+
+        # 若外部取得的 key 不在列表中，則加入列表
+        if key not in current_keys:
+            current_keys.append(key)
+
+        # 更新設定並回寫
+        await ConfigService.update_config({"API_KEYS": current_keys})
         return key
 
     @staticmethod

--- a/tests/test_refresh_external_key.py
+++ b/tests/test_refresh_external_key.py
@@ -13,6 +13,7 @@ async def test_refresh_external_key():
     settings.EXTERNAL_KEY_URL = "https://example.com/key"
     settings.EXTERNAL_KEY_SERVICE_TOKEN = "svc-token"
     settings.EXTERNAL_KEY_JWT_SECRET = "secret"
+    settings.API_KEYS = ["origin_key"]
 
     mock_response = AsyncMock()
     mock_response.text = "encoded_jwt"
@@ -32,4 +33,4 @@ async def test_refresh_external_key():
                 key = await ConfigService.refresh_external_key()
 
     assert key == "real_key"
-    assert settings.API_KEYS == ["real_key"]
+    assert settings.API_KEYS == ["origin_key", "real_key"]


### PR DESCRIPTION
## Summary
- 取得外部 key 後維持原有 API_KEYS
- 調整相應測試驗證新行為

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68523e647b00832980cbcafc23cdbdad