### PR TITLE
Add external API key list display

### DIFF
--- a/app/static/js/config_editor.js
+++ b/app/static/js/config_editor.js
@@ -1328,11 +1328,11 @@ async function refreshExternalKey() {
     }
     const data = await response.json();
     if (data.key) {
-      const container = document.getElementById("API_KEYS_container");
-      if (container) {
-        container.innerHTML = "";
-        addArrayItemWithValue("API_KEYS", data.key);
-        const input = container.querySelector(
+      addArrayItemWithValue("API_KEYS", data.key);
+      addArrayItemWithValue("EXTERNAL_API_KEYS", data.key);
+      const apiKeyContainer = document.getElementById("API_KEYS_container");
+      if (apiKeyContainer) {
+        const input = apiKeyContainer.querySelector(
           `.${ARRAY_INPUT_CLASS}.${SENSITIVE_INPUT_CLASS}`
         );
         if (input && configForm) {
@@ -1492,8 +1492,9 @@ function addArrayItemWithValue(key, value) {
   const isThinkingModel = key === "THINKING_MODELS";
   const isAllowedToken = key === "ALLOWED_TOKENS";
   const isVertexApiKey = key === "VERTEX_API_KEYS"; // 新增判断
+  const isExternalApiKey = key === "EXTERNAL_API_KEYS";
   const isSensitive =
-    key === "API_KEYS" || isAllowedToken || isVertexApiKey; // 更新敏感判断
+    key === "API_KEYS" || isAllowedToken || isVertexApiKey || isExternalApiKey; // 更新敏感判断
   const modelId = isThinkingModel ? generateUUID() : null;
  
   const arrayItem = document.createElement("div");

--- a/app/templates/config_editor.html
+++ b/app/templates/config_editor.html
@@ -979,6 +979,17 @@ endblock %} {% block head_extra_styles %}
           <small class="text-gray-500 mt-1 block">用於解密外部 Key 的 JWT 密鑰</small>
         </div>
 
+        <!-- 外部 API Key 列表 -->
+        <div class="mb-6">
+          <label for="EXTERNAL_API_KEYS" class="block font-semibold mb-2 text-gray-700"
+            >外部 API Key 列表</label
+          >
+          <div class="array-container" id="EXTERNAL_API_KEYS_container">
+            <!-- 外部 Key 將在此顯示 -->
+          </div>
+          <small class="text-gray-500 mt-1 block">從外部服務取得的 Key</small>
+        </div>
+
         <div class="mb-6 flex justify-end">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- allow display of external API key list in config editor
- keep existing API keys when refreshing external key and show it in the new list

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68526e93635c8329b8a4a8b560eddba7