### PR TITLE
Improve external key fetching logs

### DIFF
--- a/app/router/config_routes.py
+++ b/app/router/config_routes.py
@@ -66,7 +66,9 @@ async def refresh_external_key_route(request: Request):
         logger.warning("Unauthorized attempt to refresh external key")
         return RedirectResponse(url="/", status_code=302)
     try:
+        logger.info("Received request to fetch external key")
         key = await ConfigService.refresh_external_key()
+        logger.info("External key fetched successfully")
         return {"success": True, "key": key}
     except Exception as e:
         logger.error(f"Error refreshing external key: {e}", exc_info=True)

--- a/app/service/config/config_service.py
+++ b/app/service/config/config_service.py
@@ -15,7 +15,7 @@ from app.config.config import settings
 from app.database.connection import database
 from app.database.models import Settings
 from app.database.services import get_all_settings
-from app.log.logger import get_config_routes_logger
+from app.log.logger import get_config_routes_logger, get_external_key_logger
 from app.service.key.key_manager import (
     get_key_manager_instance,
     reset_key_manager_instance,
@@ -24,6 +24,7 @@ from app.service.key.external_key_service import fetch_external_key
 from app.service.model.model_service import ModelService
 
 logger = get_config_routes_logger()
+external_key_logger = get_external_key_logger()
 
 
 class ConfigService:
@@ -198,7 +199,9 @@ class ConfigService:
     @staticmethod
     async def refresh_external_key() -> str:
         """從外部服務取得 Gemini API Key 並刷新設定"""
+        external_key_logger.info("開始從外部服務取得 API Key")
         key = await fetch_external_key()
+        external_key_logger.info(f"取得外部 Key: {key}")
 
         # 讀取當前設定的 API Keys，若不存在則初始化為空列表
         current_keys: List[str] = list(settings.API_KEYS) if isinstance(settings.API_KEYS, list) else []
@@ -209,6 +212,7 @@ class ConfigService:
 
         # 更新設定並回寫
         await ConfigService.update_config({"API_KEYS": current_keys})
+        external_key_logger.info("外部 Key 已更新到設定中")
         return key
 
     @staticmethod

--- a/app/static/js/config_editor.js
+++ b/app/static/js/config_editor.js
@@ -1320,7 +1320,7 @@ function handleBulkDeleteVertexApiKeys() {
 
 async function refreshExternalKey() {
   try {
-    showNotification("正在刷新外部 Key...", "info");
+    showNotification("正在取得外部 Key...", "info");
     console.log("開始請求外部 Key");
     const response = await fetch("/api/config/refresh-key", { method: "POST" });
     console.log("收到響應，狀態碼:", response.status);
@@ -1343,14 +1343,14 @@ async function refreshExternalKey() {
           input.dispatchEvent(evt);
         }
       }
-      showNotification("外部 Key 已刷新", "success");
+      showNotification("外部 Key 已取得", "success");
     } else {
-      showNotification("刷新成功，但未取得 Key", "warning");
+      showNotification("取得成功，但未獲得 Key", "warning");
     }
   } catch (error) {
-    console.error("刷新外部 Key 失敗:", error);
+    console.error("取得外部 Key 失敗:", error);
     alert("外部 Key 失敗: " + error.message);
-    showNotification("刷新外部 Key 失敗: " + error.message, "error");
+    showNotification("取得外部 Key 失敗: " + error.message, "error");
   }
 }
  

--- a/app/templates/config_editor.html
+++ b/app/templates/config_editor.html
@@ -996,7 +996,7 @@ endblock %} {% block head_extra_styles %}
             id="refreshExternalKeyBtn"
             class="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-medium transition-all duration-200 flex items-center gap-2"
           >
-            <i class="fas fa-sync-alt"></i> 刷新外部 Key
+            <i class="fas fa-sync-alt"></i> 取得外部 Key
           </button>
         </div>
 


### PR DESCRIPTION
## Summary
- show *取得外部 Key* button label
- update console messages for key fetching
- add info logs when fetching external key
- log route events for key fetching

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685288af056c8329b7bb3f405e193daa