### PR TITLE
Add logs for external key fetch

### DIFF
--- a/app/static/js/config_editor.js
+++ b/app/static/js/config_editor.js
@@ -451,7 +451,11 @@ document.addEventListener("DOMContentLoaded", function () {
 
   const refreshExternalKeyBtn = document.getElementById("refreshExternalKeyBtn");
   if (refreshExternalKeyBtn) {
-    refreshExternalKeyBtn.addEventListener("click", refreshExternalKey);
+    console.log("Binding click event to refreshExternalKeyBtn");
+    refreshExternalKeyBtn.addEventListener("click", () => {
+      console.log("refreshExternalKeyBtn clicked");
+      refreshExternalKey();
+    });
   }
 
   // Model Helper Modal Event Listeners


### PR DESCRIPTION
## Summary
- confirm click binding for external key refresh
- log binding and click for refreshExternalKeyBtn

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68528be0cf048329a30952bb090e19ee