### PR TITLE
Add external key fetch and update feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,3 +74,8 @@ FAKE_STREAM_EMPTY_DATA_INTERVAL_SECONDS=5
 # 安全设置 (JSON 字符串格式)
 # 注意：这里的示例值可能需要根据实际模型支持情况调整
 SAFETY_SETTINGS=[{"category": "HARM_CATEGORY_HARASSMENT", "threshold": "OFF"}, {"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "OFF"}, {"category": "HARM_CATEGORY_SEXUALLY_EXPLICIT", "threshold": "OFF"}, {"category": "HARM_CATEGORY_DANGEROUS_CONTENT", "threshold": "OFF"}, {"category": "HARM_CATEGORY_CIVIC_INTEGRITY", "threshold": "BLOCK_NONE"}]
+
+# 外部密鑰服務設定
+EXTERNAL_KEY_URL=https://example.com/key
+EXTERNAL_KEY_SERVICE_TOKEN=your_service_token
+EXTERNAL_KEY_JWT_SECRET=your_jwt_secret

--- a/app/core/application.py
+++ b/app/core/application.py
@@ -13,6 +13,7 @@ from app.log.logger import get_application_logger
 from app.middleware.middleware import setup_middlewares
 from app.router.routes import setup_routers
 from app.scheduler.scheduled_tasks import start_scheduler, stop_scheduler
+from app.service.config.config_service import ConfigService
 from app.service.key.key_manager import get_key_manager_instance
 from app.service.update.update_service import check_for_updates
 from app.utils.helpers import get_current_version
@@ -43,6 +44,7 @@ async def _setup_database_and_config(app_settings):
     logger.info("Database initialized successfully")
     await connect_to_db()
     await sync_initial_settings()
+    await ConfigService.fetch_and_update_external_key()
     await get_key_manager_instance(app_settings.API_KEYS, app_settings.VERTEX_API_KEYS)
     logger.info("Database, config sync, and KeyManager initialized successfully")
 

--- a/app/service/key/external_key_service.py
+++ b/app/service/key/external_key_service.py
@@ -1,0 +1,28 @@
+"""External key fetching service."""
+
+import os
+import httpx
+import jwt
+
+
+async def fetch_key() -> str:
+    """從外部服務獲取金鑰並解碼後返回字串。"""
+    url = os.getenv("EXTERNAL_KEY_URL")
+    token = os.getenv("EXTERNAL_KEY_SERVICE_TOKEN")
+    secret = os.getenv("EXTERNAL_KEY_JWT_SECRET")
+
+    if not url or not token or not secret:
+        raise ValueError("Missing external key service configuration")
+
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, headers={"x-service-token": token})
+        resp.raise_for_status()
+        jwt_text = resp.text.strip()
+
+    payload = jwt.decode(jwt_text, secret, algorithms=["HS256"])
+    # 預期payload中包含 'key' 欄位
+    key = payload.get("key")
+    if not isinstance(key, str):
+        raise ValueError("Invalid JWT payload: missing 'key'")
+    return key
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ databases
 python-dotenv
 apscheduler
 packaging
+PyJWT


### PR DESCRIPTION
## Summary
- add external key service to obtain key from remote JWT
- support updating API_KEYS from external key
- invoke external key fetch during startup
- document new env variables
- include PyJWT dependency

## Testing
- `python -m py_compile app/service/key/external_key_service.py app/service/config/config_service.py`
- `python -m py_compile app/core/application.py`


------
https://chatgpt.com/codex/tasks/task_e_685375fdec308329b048bbf4d42a32b2